### PR TITLE
Upgrade to cflinuxfs3

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,4 @@ instances: 2
 command: npm start
 services:
 - analytics-reporter-database
+stack: cflinuxfs3


### PR DESCRIPTION
We need to do this because cloud.gov will stop supporting cflinuxfs3 (from what I can tell we need to be explicit about wanting to be on the new stack).