### PR TITLE
Use ZDT push in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,6 @@ jobs:
       - run:
           name: deploy site
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "jmhooper-zdt-deploys" ]; then
               bin/deploy-ci.sh
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,6 @@ jobs:
       - run:
           name: deploy site
           command: |
-            if [ "${CIRCLE_BRANCH}" == "jmhooper-zdt-deploys" ]; then
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
               bin/deploy-ci.sh
             fi

--- a/bin/deploy-ci.sh
+++ b/bin/deploy-ci.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Install CF
-curl https://s3-us-west-1.amazonaws.com/cf-cli-releases/releases/v6.25.0/cf-cli_6.25.0_linux_x86-64.tgz | tar xzvf -
+curl https://s3-us-west-1.amazonaws.com/cf-cli-releases/releases/v6.46.1/cf-cli_6.46.1_linux_x86-64.tgz | tar xzvf -
 sudo mv cf /usr/local/bin/cf
 
 # Log into cloud.gov
@@ -11,6 +11,6 @@ cf api api.fr.cloud.gov
 cf login -u $CF_USERNAME -p $CF_PASSWORD -o gsa-opp-analytics -s analytics-dev
 
 # Push the app
-cf push analytics-reporter-api
+cf v3-zdt-push analytics-reporter-api
 
 cf logout


### PR DESCRIPTION
This PR wires up CI so that it uses ZDT pushes to deploy from CI so that deploys don't incur downtime.