### PR TITLE
Pin buildpack to earlier version until we've tested + upgraded Node

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,10 @@
 ---
 name: analytics-api
-buildpack: nodejs_buildpack
+# We're pinning the buildpack temporarily to a version that supports Node 10.x
+# Support for those versions was removed in v1.7.53 of the buildpack:
+# https://github.com/cloudfoundry/nodejs-buildpack/releases/tag/v1.7.53
+# TODO - update the app to use a newer (still supported) version of Node
+buildpack: https://github.com/cloudfoundry/nodejs-buildpack#v1.7.52
 memory: 128M
 instances: 2
 command: npm start


### PR DESCRIPTION
This is a temporary mitigation until we've had time to upgrade Node and test the app with that newer version. This is part of addressing https://github.com/18F/analytics-reporter-api/issues/159