### PR TITLE
Change order by clause, add multi-column index to speed up queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,41 @@ migrates the database.
 npm test
 ```
 
+# Creating a new database migration
+If you need to migrate the database, you can create a new migration via `knex`, which will create the migration file for you based in part on the migration name you provide. From the root of this repo, run:
+```
+`npm bin`/knex migrate:make <the name of your migration>
+```
+
+See [knex documentation](https://knexjs.org/#Installation-migrations) for more details.
+
+# Running database migrations
+## Locally
+`npm run migrate`
+## In production
+In production, you can run database migrations via `cf run-task`. As with anything in production, be careful when doing this! First, try checking the current status of migrations using the `migrate:status` command
+```
+cf run-task analytics-reporter-api "knex migrate:status" --name check_migration_status
+```
+This will kick off a task - you can see the output by running:
+```
+cf logs analytics-reporter-api --recent
+# the output will look something like...
+2021-07-19T14:31:39.89-0400 [APP/TASK/check_migration_status/0] OUT Using environment: production
+2021-07-19T14:31:40.16-0400 [APP/TASK/check_migration_status/0] OUT Found 3 Completed Migration file/files.
+2021-07-19T14:31:40.16-0400 [APP/TASK/check_migration_status/0] OUT 20170308164751_create_analytics_data.js
+2021-07-19T14:31:40.16-0400 [APP/TASK/check_migration_status/0] OUT 20170316115145_add_analytics_data_indexes.js
+2021-07-19T14:31:40.16-0400 [APP/TASK/check_migration_status/0] OUT 20170522094056_rename_date_time_to_date.js
+2021-07-19T14:31:40.16-0400 [APP/TASK/check_migration_status/0] OUT No Pending Migration files Found.
+2021-07-19T14:31:40.17-0400 [APP/TASK/check_migration_status/0] OUT Exit status 0
+```
+
+To actually run the migration, you would run:
+```
+cf run-task analytics-reporter-api "knex migrate:latest" --name run_db_migrations
+```
+
+See [knex documentation](https://knexjs.org/#Installation-migrations) for more details and options on the `migrate` command.
 ### Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in

--- a/migrations/20210706213753_add_date_id_multi_col_index.js
+++ b/migrations/20210706213753_add_date_id_multi_col_index.js
@@ -1,0 +1,10 @@
+exports.up = function(knex) {
+    return knex.schema.raw("CREATE INDEX analytics_data_date_desc_id_asc ON analytics_data (date DESC NULLS LAST, id ASC)")
+  };
+  
+  exports.down = function(knex, Promise) {
+    return knex.schema.table("analytics_data", table => {
+      table.dropIndex("analytics_data_date_desc_id_asc")
+    })
+  };
+  


### PR DESCRIPTION
## Current state
There is a bunch of discussion around this here: https://github.com/18F/analytics-reporter-api/issues/161

The tl;dr is that all endpoints are extremely slow right now. Based on the investigation above, I feel pretty confident that it's an issue with DB queries being extremely slow. According to New Relic, in the last week:

* `get /v1.1/domain/:domain/reports/:reportName/data` averages 112 seconds response time
* `get /v1.1/agencies/:reportAgency/reports/:reportName/data` averages 7 seconds response time
* `get /v1.1/reports/:reportName/data` averages 4 seconds response time

The diagnosing of the source of the slowness is mostly documented in the issue linked to above. The ordering used in all queries now is:
```
order by "date" desc NULLS LAST,
CAST(data->>'total_events' AS INTEGER) desc,
CAST(data->>'visits' AS INTEGER) desc
```
The tl;dr is that this ordering isn't able to use any existing indexes, and there's no way (from what I could find) to add a multi-column index that includes specific JSON fields (i.e. the `data->>'total_events' and `data->>'visits'` fields).

## Proposed changes

1. Changes the `order by` clause to use `id` as a secondary sort key (after `date`)
2. Adds a multi column index to support the `ORDER BY date desc NULLS LAST, id` clause

Note that changing the `order by` clause can alter the ordering of data from what happens today. In practice, it seems like the data order won't change, because data happens to be inserted into the database in decreasing order by `visits` or `total_events`.

I am open to other ideas of addressing these performance issues, but this seemed to be the most promising. In the longer term, I would suggest we consider moving data out of the generic `data` JSON column into specific columns for each field (i.e. `total_events` and `visits` should each have their own columns).

Note that this change is reversible; if for any reason we want to go back to using the previous `ORDER BY` clause, we can do that with no problem. 