### PR TITLE
cflinuxfs4 fix

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -10,4 +10,4 @@ instances: 2
 command: npm start
 services:
 - analytics-reporter-database
-stack: cflinuxfs3
+stack: cflinuxfs4


### PR DESCRIPTION

This PR tracks work on remediating the Clloud.gov Ubuntu stack dependency moving from cflinuxfs3 to 4.