### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/18F/analytics-reporter-api/security/code-scanning/10](https://github.com/18F/analytics-reporter-api/security/code-scanning/10)

In general, the fix is to explicitly declare `permissions` for the workflow so that the `GITHUB_TOKEN` is not using broad repository defaults. Since all visible jobs only need to read the repository (checkout code, install dependencies, run lint/tests, and then call a reusable workflow), we can safely grant `contents: read` at the top level. This will apply to all jobs that do not override `permissions`.

The best minimal, non‑breaking change is to add a root‑level `permissions:` block near the top of `.github/workflows/ci.yml`, alongside `on:` and `jobs:`. We’ll set `permissions: contents: read`, which is sufficient for `actions/checkout@v4` and typical uses of `GITHUB_TOKEN` in CI. We won’t touch the jobs themselves or the deploy configuration, preserving existing behavior.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert a new top‑level section:
  ```yaml
  permissions:
    contents: read
  ```
  between the `on:` section and the `jobs:` section (after line 4 and before line 5 in the snippet).
- No additional imports, methods, or definitions are required, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
