### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_to_dev_manually.yml
+++ b/.github/workflows/deploy_to_dev_manually.yml
@@ -1,11 +1,12 @@
 name: Deploy to dev manually
-permissions: read-all
 
 on:
   workflow_dispatch:
 
 jobs:
   deploy_dev:
+    permissions:
+      contents: read
     uses: 18F/analytics-reporter-api/.github/workflows/deploy.yml@develop
     with:
       APP_NAME: ${{ vars.APP_NAME_DEV }}

--- a/.github/workflows/deploy_to_dev_manually.yml
+++ b/.github/workflows/deploy_to_dev_manually.yml
@@ -1,4 +1,5 @@
 name: Deploy to dev manually
+permissions: read-all
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/18F/analytics-reporter-api/security/code-scanning/4](https://github.com/18F/analytics-reporter-api/security/code-scanning/4)

To fix the problem, declare an explicit `permissions` block so that the `GITHUB_TOKEN` used by this workflow is not implicitly granted broad repository permissions. The safest, functionality-preserving starting point is to set the workflow-level permissions to read-only using `permissions: read-all`. This ensures all jobs (including the `deploy_dev` job that calls the reusable workflow) run with a read-only token unless they override it.

Concretely, update `.github/workflows/deploy_to_dev_manually.yml` near the top, after the `name:` line and before `on:`, to add:

```yaml
permissions: read-all
```

This is a minimal, explicit restriction that does not grant any write access. If the reusable workflow needs specific write scopes, it should request them in its own `permissions` block; we are not changing that file here, only making this caller workflow explicit and least-privilege by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
